### PR TITLE
add access to PluginUtil type

### DIFF
--- a/src/main/kotlin/org/veupathdb/service/eda/compute/exec/PluginExecutor.kt
+++ b/src/main/kotlin/org/veupathdb/service/eda/compute/exec/PluginExecutor.kt
@@ -5,14 +5,15 @@ import org.apache.logging.log4j.ThreadContext
 import org.veupathdb.lib.compute.platform.job.JobContext
 import org.veupathdb.lib.compute.platform.job.JobExecutor
 import org.veupathdb.lib.compute.platform.job.JobResult
-import org.veupathdb.lib.compute.platform.job.JobWorkspace
 import org.veupathdb.lib.jackson.Json
+import org.veupathdb.service.eda.common.client.EdaMergingClient
 import org.veupathdb.service.eda.compute.EDA
 import org.veupathdb.service.eda.compute.jobs.ReservedFiles
 import org.veupathdb.service.eda.compute.plugins.Plugin
 import org.veupathdb.service.eda.compute.plugins.AbstractPlugin
 import org.veupathdb.service.eda.compute.plugins.PluginRegistry
 import org.veupathdb.service.eda.compute.plugins.PluginWorkspace
+import org.veupathdb.service.eda.compute.service.ServiceOptions
 
 /**
  * Standard set of files we will attempt to persist to S3 on "successful" job
@@ -136,6 +137,7 @@ class PluginExecutor : JobExecutor {
       it.workspace = PluginWorkspace(ctx.workspace)
       it.jobContext = ComputeJobContext(ctx.jobID)
       it.pluginMeta = provider
+      it.mergingClient = EdaMergingClient(ServiceOptions.edaMergeHost, authHeader)
     }.build()
 
     // Create the plugin.

--- a/src/main/kotlin/org/veupathdb/service/eda/compute/plugins/AbstractPlugin.kt
+++ b/src/main/kotlin/org/veupathdb/service/eda/compute/plugins/AbstractPlugin.kt
@@ -1,7 +1,7 @@
 package org.veupathdb.service.eda.compute.plugins
 
 import org.apache.logging.log4j.LogManager
-import org.veupathdb.service.eda.common.client.spec.StreamSpec
+import org.veupathdb.service.eda.common.plugin.util.PluginUtil
 import org.veupathdb.service.eda.compute.jobs.ReservedFiles
 import org.veupathdb.service.eda.compute.metrics.PluginMetrics
 import org.veupathdb.service.eda.generated.model.APIStudyDetail
@@ -102,6 +102,12 @@ abstract class AbstractPlugin<R : ComputeRequestBase, C>(
    */
   protected val workspace
     get() = context.workspace
+
+  /**
+   * EDA Common [PluginUtil] Instance
+   */
+  protected val util
+    get() =  PluginUtil(context.referenceMetadata, context.mergingClient)
 
   // ╔════════════════════════════════════════════════════════════════════╗ //
   // ║                                                                    ║ //

--- a/src/main/kotlin/org/veupathdb/service/eda/compute/plugins/PluginContext.kt
+++ b/src/main/kotlin/org/veupathdb/service/eda/compute/plugins/PluginContext.kt
@@ -1,5 +1,6 @@
 package org.veupathdb.service.eda.compute.plugins
 
+import org.veupathdb.service.eda.common.client.EdaMergingClient
 import org.veupathdb.service.eda.common.model.ReferenceMetadata
 import org.veupathdb.service.eda.compute.exec.ComputeJobContext
 import org.veupathdb.service.eda.compute.process.ComputeProcessBuilder
@@ -65,6 +66,11 @@ interface PluginContext<R: ComputeRequestBase, C> {
   val referenceMetadata: ReferenceMetadata
 
   /**
+   * EDA Merging Client Instance
+   */
+  val mergingClient: EdaMergingClient
+
+  /**
    * Returns a new [ComputeProcessBuilder] which may be used to construct an
    * external process execution and run that external process.
    *
@@ -101,6 +107,8 @@ class PluginContextBuilder<R : ComputeRequestBase, C> {
 
   var studyDetail: APIStudyDetail? = null
 
+  var mergingClient: EdaMergingClient? = null
+
   fun request(request: R): PluginContextBuilder<R, C> {
     this.request = request
     return this
@@ -126,13 +134,19 @@ class PluginContextBuilder<R : ComputeRequestBase, C> {
     return this
   }
 
+  fun mergingClient(mergingClient: EdaMergingClient): PluginContextBuilder<R, C> {
+    this.mergingClient = mergingClient
+    return this
+  }
+
   fun build(): PluginContext<R, C> =
     PluginContextImpl(
-      request     ?: throw IllegalStateException("request must not be null"),
-      workspace   ?: throw IllegalStateException("workspace must not be null"),
-      jobContext  ?: throw IllegalStateException("jobContext must not be null"),
-      pluginMeta  ?: throw IllegalStateException("pluginMeta must not be null"),
-      studyDetail ?: throw IllegalStateException("studyDetail must not be null")
+      request       ?: throw IllegalStateException("request must not be null"),
+      workspace     ?: throw IllegalStateException("workspace must not be null"),
+      jobContext    ?: throw IllegalStateException("jobContext must not be null"),
+      pluginMeta    ?: throw IllegalStateException("pluginMeta must not be null"),
+      studyDetail   ?: throw IllegalStateException("studyDetail must not be null"),
+      mergingClient ?: throw IllegalStateException("mergingClient must not be null"),
     )
 }
 
@@ -143,6 +157,7 @@ private class PluginContextImpl<R : ComputeRequestBase, C>(
   override val jobContext: ComputeJobContext,
   override val pluginMeta: PluginMeta<R>,
   override val studyDetail: APIStudyDetail,
+  override val mergingClient: EdaMergingClient
 ) : PluginContext<R, C> {
 
   @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
This PR adds a primary feature and a support feature:

1. The primary feature is giving access to EdaCommon's `PluginUtil` class in the compute plugin base class via the getter `getUtil()`.
2. The secondary feature supporting the primary feature is access to an EdaMergingClient instance via the plugin's given context.


```java
// Primary Feature
plugin.getUtil()

// Secondary Feature
plugin.getContext().getMergingClient()
```

Resolves #32 