### PR TITLE
refactor meta endpoints

### DIFF
--- a/api.raml
+++ b/api.raml
@@ -61,11 +61,23 @@ uses:
         200:
           body:
             application/json: lib.JobResponse
-    /{file}:
-      uriParameters:
-        file:
-          type: string
-          description: MUST be one of "meta", "tabular", "statistics".
+    /tabular:
+      post:
+        body:
+	  application/json: lib.BetaDivPluginRequest
+	responses:
+	  200:
+            body:
+	      text/tab-separated-values: lib.EntityTabularPostResponse    
+    /meta:
+      post"
+        body:
+	  application/json: lib.BetaDivPluginRequest
+	responses:
+	  200:
+	    body:
+	      application/json: lib.ComputedVariableMetadataResponse
+    /statistics:
       post:
         body:
           application/json: lib.BetaDivPluginRequest
@@ -82,11 +94,23 @@ uses:
         200:
           body:
             application/json: lib.JobResponse
-    /{file}:
-      uriParameters:
-        file:
-          type: string
-          description: MUST be one of "meta", "tabular", "statistics".
+    /tabular:
+      post:
+        body:
+          application/json: lib.AlphaDivPluginRequest
+        responses:
+          200:
+            body:
+              text/tab-separated-values: lib.EntityTabularPostResponse
+    /meta:
+      post"
+        body:
+          application/json: lib.AlphaDivPluginRequest
+        responses:
+          200:
+            body:
+              application/json: lib.ComputedVariableMetadataResponse
+    /statistics:
       post:
         body:
           application/json: lib.AlphaDivPluginRequest
@@ -103,11 +127,23 @@ uses:
         200:
           body:
             application/json: lib.JobResponse
-    /{file}:
-      uriParameters:
-        file:
-          type: string
-          description: MUST be one of "meta", "tabular", "statistics".
+    /tabular:
+      post:
+        body:
+          application/json: lib.RankedAbundancePluginRequest
+        responses:
+          200:
+            body:
+              text/tab-separated-values: lib.EntityTabularPostResponse
+    /meta:
+      post"
+        body:
+          application/json: lib.RankedAbundancePluginRequest
+        responses:
+          200:
+            body:
+              application/json: lib.ComputedVariableMetadataResponse
+    /statistics:
       post:
         body:
           application/json: lib.RankedAbundancePluginRequest

--- a/schema/url/computes.raml
+++ b/schema/url/computes.raml
@@ -19,3 +19,8 @@ types:
         items:
           type: eda.DerivedVariable
     additionalProperties: false
+
+  ComputedVariableMetadataResponse:
+    additionalProperties: false
+    properties:
+      variables: VariableMetadata[]


### PR DESCRIPTION
see https://github.com/VEuPathDB/web-eda/issues/1329 to understand the broader goal here. but essentially the meta endpoints should all follow a consistent format, essentially an array of variable metadata for all computed vars. depends on https://github.com/VEuPathDB/EdaCommon/pull/19