### PR TITLE
add optional numberVariablesReturned arg for abudnance

### DIFF
--- a/schema/url/computes/rankedAbundance.raml
+++ b/schema/url/computes/rankedAbundance.raml
@@ -11,6 +11,7 @@ types:
     properties:
       collectionVariable: VariableSpec
       rankingMethod: RankingMethod
+      numberVariablesReturned?: number
 
   RankingMethod:
     type: string

--- a/src/main/java/org/veupathdb/service/eda/compute/plugins/rankedabundance/RankedAbundancePlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/compute/plugins/rankedabundance/RankedAbundancePlugin.java
@@ -49,6 +49,7 @@ public class RankedAbundancePlugin extends AbstractPlugin<RankedAbundancePluginR
     VariableDef computeEntityIdVarSpec = util.getEntityIdVarSpec(entityId);
     String computeEntityIdColName = util.toColNameOrEmpty(computeEntityIdVarSpec);
     String method = computeConfig.getRankingMethod().getName();
+    Number numberVariablesReturned = computeConfig.getNumberVariablesReturned() != null ? computeConfig.getNumberVariablesReturned() : 10;
     HashMap<String, InputStream> dataStream = new HashMap<>();
     dataStream.put(INPUT_DATA, getWorkspace().openStream(INPUT_DATA));
     List<VariableDef> idColumns = new ArrayList<>();
@@ -81,8 +82,10 @@ public class RankedAbundancePlugin extends AbstractPlugin<RankedAbundancePluginR
                                                                           ",recordIdColumn=" + util.singleQuote(computeEntityIdColName) + 
                                                                           ",ancestorIdColumns=" + dotNotatedIdColumnsString +
                                                                           ",imputeZero=TRUE)");
-      connection.voidEval("abundanceDT <- rankedAbundance(abundDT, " +
-                                                          PluginUtil.singleQuote(method) + ")");
+      connection.voidEval("abundanceDT <- rankedAbundance(abundDT" +
+                                                          ",method=" + PluginUtil.singleQuote(method) +
+                                                          ",cutoff=" + numberVariablesReturned +
+                                                          ")");
       String dataCmd = "writeData(abundanceDT, NULL, TRUE)";
       String metaCmd = "writeMeta(abundanceDT, NULL, TRUE)";
 


### PR DESCRIPTION
Work towards https://github.com/VEuPathDB/web-eda/issues/1548

Related frontend PR: https://github.com/VEuPathDB/web-eda/pull/1584

Adds an optional argument called `numberVariablesReturned` for the ranked abundance app. This maps to the `cutoff` arg in the [rankedAbundance R method](https://github.com/VEuPathDB/microbiomeComputations/blob/master/R/method-rankedAbundance.R) (hoping "numberVariablesReturned" is more descriptive than "cutoff". Can update the R code to match later). `numberVariablesReturned` determines the final count of variables in the data coming back from this app.