### PR TITLE
fix for empty dotNotatedIdColumns

### DIFF
--- a/src/main/java/org/veupathdb/service/eda/compute/plugins/alphadiv/AlphaDivPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/compute/plugins/alphadiv/AlphaDivPlugin.java
@@ -63,12 +63,12 @@ public class AlphaDivPlugin extends AbstractPlugin<AlphaDivPluginRequest, AlphaD
       computeInputVars.addAll(idColumns);
       connection.voidEval(util.getVoidEvalFreadCommand(INPUT_DATA, computeInputVars));
       List<String> dotNotatedIdColumns = idColumns.stream().map(VariableDef::toDotNotation).collect(Collectors.toList());
-      String dotNotatedIdColumnsString = new String();
+      String dotNotatedIdColumnsString = "c(";
       boolean first = true;
       for (String idCol : dotNotatedIdColumns) {
         if (first) {
           first = false;
-          dotNotatedIdColumnsString = "c(" + util.singleQuote(idCol);
+          dotNotatedIdColumnsString = dotNotatedIdColumnsString + util.singleQuote(idCol);
         } else {
           dotNotatedIdColumnsString = dotNotatedIdColumnsString + "," + util.singleQuote(idCol);
         }
@@ -77,7 +77,7 @@ public class AlphaDivPlugin extends AbstractPlugin<AlphaDivPluginRequest, AlphaD
 
       connection.voidEval("abundDT <- microbiomeComputations::AbundanceData(data=" + INPUT_DATA + 
                                                                           ",recordIdColumn=" + util.singleQuote(computeEntityIdColName) + 
-                                                                          ",ancestorIdColumns=" + dotNotatedIdColumnsString +
+                                                                          ",ancestorIdColumns=as.character(" + dotNotatedIdColumnsString + ")" +
                                                                           ",imputeZero=TRUE)");
 
       connection.voidEval("alphaDivDT <- alphaDiv(abundDT, " +

--- a/src/main/java/org/veupathdb/service/eda/compute/plugins/betadiv/BetaDivPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/compute/plugins/betadiv/BetaDivPlugin.java
@@ -64,12 +64,12 @@ public class BetaDivPlugin extends AbstractPlugin<BetaDivPluginRequest, BetaDivC
       computeInputVars.addAll(idColumns);
       connection.voidEval(util.getVoidEvalFreadCommand(INPUT_DATA, computeInputVars));
       List<String> dotNotatedIdColumns = idColumns.stream().map(VariableDef::toDotNotation).collect(Collectors.toList());
-      String dotNotatedIdColumnsString = new String();
+      String dotNotatedIdColumnsString = "c(";
       boolean first = true;
       for (String idCol : dotNotatedIdColumns) {
         if (first) {
           first = false;
-          dotNotatedIdColumnsString = "c(" + util.singleQuote(idCol);
+          dotNotatedIdColumnsString = dotNotatedIdColumnsString + util.singleQuote(idCol);
         } else {
           dotNotatedIdColumnsString = dotNotatedIdColumnsString + "," + util.singleQuote(idCol);
         }
@@ -78,7 +78,7 @@ public class BetaDivPlugin extends AbstractPlugin<BetaDivPluginRequest, BetaDivC
 
       connection.voidEval("abundDT <- microbiomeComputations::AbundanceData(data=" + INPUT_DATA + 
                                                                           ",recordIdColumn=" + util.singleQuote(computeEntityIdColName) + 
-                                                                          ",ancestorIdColumns=" + dotNotatedIdColumnsString +
+                                                                          ",ancestorIdColumns=as.character(" + dotNotatedIdColumnsString + ")" +
                                                                           ",imputeZero=TRUE)");
       connection.voidEval("betaDivDT <- betaDiv(abundDT, " +
                                                 PluginUtil.singleQuote(distanceMethod) + ")");

--- a/src/main/java/org/veupathdb/service/eda/compute/plugins/rankedabundance/RankedAbundancePlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/compute/plugins/rankedabundance/RankedAbundancePlugin.java
@@ -65,12 +65,12 @@ public class RankedAbundancePlugin extends AbstractPlugin<RankedAbundancePluginR
       connection.voidEval(util.getVoidEvalFreadCommand(INPUT_DATA, computeInputVars));
       // TODO make a helper for this i think
       List<String> dotNotatedIdColumns = idColumns.stream().map(VariableDef::toDotNotation).collect(Collectors.toList());
-      String dotNotatedIdColumnsString = new String();
+      String dotNotatedIdColumnsString = "c(";
       boolean first = true;
       for (String idCol : dotNotatedIdColumns) {
         if (first) {
           first = false;
-          dotNotatedIdColumnsString = "c(" + util.singleQuote(idCol);
+          dotNotatedIdColumnsString = dotNotatedIdColumnsString + util.singleQuote(idCol);
         } else {
           dotNotatedIdColumnsString = dotNotatedIdColumnsString + "," + util.singleQuote(idCol);
         }
@@ -79,7 +79,7 @@ public class RankedAbundancePlugin extends AbstractPlugin<RankedAbundancePluginR
 
       connection.voidEval("abundDT <- microbiomeComputations::AbundanceData(data=" + INPUT_DATA + 
                                                                           ",recordIdColumn=" + util.singleQuote(computeEntityIdColName) + 
-                                                                          ",ancestorIdColumns=" + dotNotatedIdColumnsString +
+                                                                          ",ancestorIdColumns=as.character(" + dotNotatedIdColumnsString + ")" +
                                                                           ",imputeZero=TRUE)");
       connection.voidEval("abundanceDT <- rankedAbundance(abundDT, " +
                                                           PluginUtil.singleQuote(method) + ")");


### PR DESCRIPTION
during diy testing, @jbrestel noticed all computes were failing with his uploaded data. We found the data had no ancestor id columns, which led to `dotNotatedIdColumnsString = )`. 

This PR provides a fix which handles the no-ancestor-id case.

@d-callan i wasn't clever enough to get rid of the for loop - it still is used to put the ',' s in the right places.
