### PR TITLE
Avoid async platform race condition.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -167,7 +167,7 @@ dependencies {
 
   implementation("org.veupathdb.lib:jaxrs-container-core:${containerCore}")
   implementation(findProject(":edaCommon") ?: "org.veupathdb.service.eda:eda-common:${edaCommon}")
-  implementation("org.veupathdb.lib:compute-platform:1.5.0")
+  implementation("org.veupathdb.lib:compute-platform:1.5.2")
 
   // Jersey
   implementation("org.glassfish.jersey.core:jersey-server:3.1.1")

--- a/makefile
+++ b/makefile
@@ -80,6 +80,14 @@ jar: build/libs/service.jar
 docker:
 	./gradlew build-docker --stacktrace
 
+.PHONY: docker-release
+docker-release:
+	@docker build \
+		-t veupathdb/eda-compute \
+		--build-arg=GITHUB_USERNAME=${GITHUB_USERNAME} \
+		--build-arg=GITHUB_TOKEN=${GITHUB_TOKEN} \
+		.
+
 #
 # File based targets
 #

--- a/src/main/kotlin/org/veupathdb/service/eda/compute/EDA.kt
+++ b/src/main/kotlin/org/veupathdb/service/eda/compute/EDA.kt
@@ -171,7 +171,10 @@ object EDA {
       }
 
       // Look up the job we just submitted
-      return AsyncPlatform.getJob(jobID)!!.toJobResponse()
+      return JobResponseImpl().also {
+        it.jobID = jobID.string
+        it.status = JobStatus.QUEUED
+      }
     }
 
     // Return the job ID with no-such-job status


### PR DESCRIPTION
Rather than calling `getJob` immediately after submitting the job, frequently hitting the race condition described [here](https://github.com/VEuPathDB/lib-compute-platform/issues/48#issuecomment-1540235548) return a dumb response with the job ID and queued status.