### PR TITLE
Use parallel stream to look up job attributes (independent operations)

### DIFF
--- a/src/main/java/org/veupathdb/service/eda/compute/controller/ExpirationController.java
+++ b/src/main/java/org/veupathdb/service/eda/compute/controller/ExpirationController.java
@@ -49,7 +49,7 @@ public class ExpirationController implements ExpireComputeJobs {
   }
 
   private List<HashID> findJobs(Optional<String> jobIdOption, Optional<String> studyIdOption, Optional<String> pluginNameOption) {
-    return AsyncPlatform.listJobReferences().stream()
+    return AsyncPlatform.listJobReferences().parallelStream()
 
         // can only expire owned jobs
         .filter(JobReference::getOwned)


### PR DESCRIPTION
The EDA compute expiration endpoint on prod (south) takes >2 mins (3.5 now but will grow) to come back, causing a 502 proxy error response rather than a 200 with some JSON telling how many jobs were expired.  I'm not sure this will fix this, but will speed it up a little at least.  Asking for PR because I've never used parallel streams before and wondered if you all knew of any gotchas.  Also Ellie, maybe make sure the stuff I'm doing in there is threadsafe?