### PR TITLE
allow ud in correlation metadata app and remove dates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,7 +117,7 @@ repositories {
 
 // project versions
 val containerCore = "6.20.0"
-val edaCommon =     "11.6.6"
+val edaCommon =     "11.6.7"
 
 // use local EdaCommon compiled schema if project exists, else use released version;
 //    this mirrors the way we use local EdaCommon code if available

--- a/src/main/java/org/veupathdb/service/eda/compute/plugins/correlationassaymetadata/CorrelationAssayMetadataPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/compute/plugins/correlationassaymetadata/CorrelationAssayMetadataPlugin.java
@@ -10,6 +10,7 @@ import org.veupathdb.service.eda.common.model.EntityDef;
 import org.veupathdb.service.eda.common.model.ReferenceMetadata;
 import org.veupathdb.service.eda.common.model.VariableDef;
 import org.veupathdb.service.eda.common.plugin.util.PluginUtil;
+import org.veupathdb.service.eda.common.model.VariableSource;
 import org.veupathdb.service.eda.compute.RServe;
 import org.veupathdb.service.eda.compute.plugins.AbstractPlugin;
 import org.veupathdb.service.eda.compute.plugins.PluginContext;
@@ -60,18 +61,16 @@ public class CorrelationAssayMetadataPlugin extends AbstractPlugin<CorrelationAs
 
       LOG.info("No ancestors found, using all variables that are not part of a collection.");
       
-      // Grab all non-id variables from this entity
-      metadataVariables = entity.getVariables().stream()
-          .filter(var -> !var.getVariableId().contains("_stable_id"))
-          .collect(Collectors.toList());
-
       // List the variables that are already in collections
       List<VariableDef> variablesInACollection = entity.getCollections().stream()
-          .flatMap(collection -> collection.getMemberVariables().stream())
-          .collect(Collectors.toList());
+      .flatMap(collection -> collection.getMemberVariables().stream())
+      .collect(Collectors.toList());
 
       // Remove variables that are already in a collection from the metadata variables list.
-      metadataVariables.removeAll(variablesInACollection);
+      metadataVariables = entity.getVariables().stream()
+          .filter(var -> var.getSource() != VariableSource.ID)
+          .filter(var -> !variablesInACollection.contains(var))
+          .collect(Collectors.toList());
 
     } else {
       
@@ -79,7 +78,7 @@ public class CorrelationAssayMetadataPlugin extends AbstractPlugin<CorrelationAs
       metadataVariables = ancestors.stream() // Get all ancestors of entity.
           .filter(ancestor -> !getManyToOneWithDescendant(metadata, ancestor, entity)) // Filter to those that are one-to-one with target entity or ancestor of entity.
           .flatMap(entityDef -> entityDef.getVariables().stream()) // Flatten stream of var streams into a single stream of vars.
-          .filter(var -> !var.getVariableId().contains("_stable_id")) // Filter out id variables
+          .filter(var -> var.getSource() != VariableSource.ID) // Filter out id variables
           .collect(Collectors.toList());
 
     }
@@ -140,11 +139,6 @@ public class CorrelationAssayMetadataPlugin extends AbstractPlugin<CorrelationAs
     List<VariableDef> metadataVariables;
     if (ancestors.isEmpty()) {
       LOG.info("No ancestors found, using all variables that are not part of a collection.");
-      
-      // Grab all non-id variables from this entity
-      metadataVariables = entity.getVariables().stream()
-          .filter(var -> !var.getVariableId().contains("_stable_id"))
-          .collect(Collectors.toList());
 
       // List the variables that are already in collections
       List<VariableDef> variablesInACollection = entity.getCollections().stream()
@@ -152,7 +146,10 @@ public class CorrelationAssayMetadataPlugin extends AbstractPlugin<CorrelationAs
           .collect(Collectors.toList());
 
       // Remove variables that are already in a collection from the metadata variables list.
-      metadataVariables.removeAll(variablesInACollection);
+      metadataVariables = entity.getVariables().stream()
+          .filter(var -> var.getSource() != VariableSource.ID)
+          .filter(var -> !variablesInACollection.contains(var))
+          .collect(Collectors.toList());
 
     } else {
 
@@ -160,7 +157,7 @@ public class CorrelationAssayMetadataPlugin extends AbstractPlugin<CorrelationAs
       metadataVariables = ancestors.stream() // Get all ancestors of entity.
           .filter(ancestor -> !getManyToOneWithDescendant(metadata, ancestor, entity)) // Filter to those that are one-to-one with target entity or ancestor of entity.
           .flatMap(entityDef -> entityDef.getVariables().stream()) // Flatten stream of var streams into a single stream of vars.
-          .filter(var -> !var.getVariableId().contains("_stable_id")) // Filter out id variables
+          .filter(var -> var.getSource() != VariableSource.ID) // Filter out id variables
           .collect(Collectors.toList());
     }
 

--- a/src/main/java/org/veupathdb/service/eda/compute/plugins/correlationassaymetadata/CorrelationAssayMetadataPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/compute/plugins/correlationassaymetadata/CorrelationAssayMetadataPlugin.java
@@ -86,7 +86,7 @@ public class CorrelationAssayMetadataPlugin extends AbstractPlugin<CorrelationAs
 
     // Filter variables to only include those that are continuous
     metadataVariables = metadataVariables.stream()
-      .filter(var -> var.getDataShape() == APIVariableDataShape.CONTINUOUS && var.getSource().isResident() && (var.getDataType() == APIVariableDataType.NUMBER || var.getDataType() == APIVariableDataType.INTEGER)) // Filter out inherited and non-continuous, non-date variables.
+      .filter(var -> var.getDataShape() == APIVariableDataShape.CONTINUOUS && var.getSource().isResident()) // Filter out inherited and non-continuous variables.
       .collect(Collectors.toList());
 
     LOG.info("Using the following metadata variables for correlation: {}",
@@ -166,7 +166,7 @@ public class CorrelationAssayMetadataPlugin extends AbstractPlugin<CorrelationAs
 
     // Filter variables to only include those that are continuous
     List<VariableDef> finalMetadataVariables = metadataVariables.stream()
-      .filter(var -> var.getDataShape() == APIVariableDataShape.CONTINUOUS && var.getSource().isResident() && (var.getDataType() == APIVariableDataType.NUMBER || var.getDataType() == APIVariableDataType.INTEGER)) // Filter out inherited and non-continuous, non-date variables.
+      .filter(var -> var.getDataShape() == APIVariableDataShape.CONTINUOUS && var.getSource().isResident()) // Filter out inherited and non-continuous variables.
       .collect(Collectors.toList());
 
     LOG.info("Using the following metadata variables for correlation: {}",

--- a/src/main/java/org/veupathdb/service/eda/compute/plugins/correlationassaymetadata/CorrelationAssayMetadataPlugin.java
+++ b/src/main/java/org/veupathdb/service/eda/compute/plugins/correlationassaymetadata/CorrelationAssayMetadataPlugin.java
@@ -86,7 +86,7 @@ public class CorrelationAssayMetadataPlugin extends AbstractPlugin<CorrelationAs
 
     // Filter variables to only include those that are continuous
     metadataVariables = metadataVariables.stream()
-      .filter(var -> var.getDataShape() == APIVariableDataShape.CONTINUOUS && var.getSource().isResident()) // Filter out inherited and non-continuous variables.
+      .filter(var -> var.getDataShape() == APIVariableDataShape.CONTINUOUS && var.getSource().isResident() && (var.getDataType() == APIVariableDataType.NUMBER || var.getDataType() == APIVariableDataType.INTEGER)) // Filter out inherited and non-continuous, non-date variables.
       .collect(Collectors.toList());
 
     LOG.info("Using the following metadata variables for correlation: {}",
@@ -166,7 +166,7 @@ public class CorrelationAssayMetadataPlugin extends AbstractPlugin<CorrelationAs
 
     // Filter variables to only include those that are continuous
     List<VariableDef> finalMetadataVariables = metadataVariables.stream()
-      .filter(var -> var.getDataShape() == APIVariableDataShape.CONTINUOUS && var.getSource().isResident()) // Filter out inherited and non-continuous variables.
+      .filter(var -> var.getDataShape() == APIVariableDataShape.CONTINUOUS && var.getSource().isResident() && (var.getDataType() == APIVariableDataType.NUMBER || var.getDataType() == APIVariableDataType.INTEGER)) // Filter out inherited and non-continuous, non-date variables.
       .collect(Collectors.toList());
 
     LOG.info("Using the following metadata variables for correlation: {}",


### PR DESCRIPTION
For use with https://github.com/VEuPathDB/web-monorepo/pull/753 in the frontend

The current restrictions for the correlation assay x metadata app require datasets to have at least two entities. User datasets only have one entity, so they'll never get to see this correlation app. What a shame!

This PR lets the user datasets join the party by breaking up the check for appropriate metadata into two cases based on if the given entity has 0 or >=1 ancestors. If the entity has no ancestors, then we want to call "metadata" any variable on the entity that is not part of a collection. Once we have our metadata, we can apply the usual filters of `dataShape = CONTINUOUS` and so on.

